### PR TITLE
feat: add getState injection in contexts with actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,20 +171,21 @@ export const CounterContainer = () => {
 
 The action context contain all the data needed to implement the actions. It contains the action arguments and the injected data.
 
-| Property      | Alias | Availability                   | Description                                             |
-| ------------- | ----- | ------------------------------ | ------------------------------------------------------- |
-| state         | s     | everywhere                     | Current state                                           |
-| args          |       | action related                 | Action arguments                                        |
-| props         | p     | everywhere                     | Current bound component props                           |
-| actions       | a     | side effects / onMount         | Store actions (decorated)                               |
-| result        | res   | promise effects / side effects | The promise result                                      |
-| error         | err   | error effects / side effects   | The promise error                                       |
-| derived       | ds    | everywhere                     | The derived state (from props/state)                    |
-| promiseId     |       | asynchronous actions callbacks | Parallel asynchronous actions promise identifier        |
-| notifyWarning |       | side effects                   | Injected function if set at store or global level       |
-| clearError    |       | side effects                   | Clear an error from ErrorMap                            |
-| indices       |       | onPropsChange                  | Indices in the getDeps array of changed props           |
-| isInit        |       | onPropsChange                  | Whether the onPropsCHange is executed during init phase |
+| Property      | Alias    | Availability                        | Description                                                            |
+| ------------- | -------- | ----------------------------------- | ---------------------------------------------------------------------- |
+| state         | s        | everywhere                          | Current state                                                          |
+| args          |          | action related                      | Action arguments                                                       |
+| props         | p        | everywhere                          | Current bound component props                                          |
+| actions       | a        | getPromise / side effects / onMount | Store actions (decorated)                                              |
+| result        | res      | promise effects / side effects      | The promise result                                                     |
+| error         | err      | error effects / side effects        | The promise error                                                      |
+| derived       | ds       | everywhere                          | The derived state (from props/state)                                   |
+| promiseId     |          | asynchronous actions callbacks      | Parallel asynchronous actions promise identifier                       |
+| getState      | getState | getPromise / side effects / onMount | A function to get the current state (after an action call for example) |
+| notifyWarning |          | side effects                        | Injected function if set at store or global level                      |
+| clearError    |          | side effects                        | Clear an error from ErrorMap                                           |
+| indices       |          | onPropsChange                       | Indices in the getDeps array of changed props                          |
+| isInit        |          | onPropsChange                       | Whether the onPropsCHange is executed during init phase                |
 
 # Actions
 

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -328,7 +328,7 @@ export function computeAsyncActionInput<S, DS, F extends (...args: any[]) => any
       ...(action as any),
       getPromise: action.getGetPromise,
       retryCount: 3,
-      conflictPolicy: ConflictPolicy.REUSE,
+      conflictPolicy: action.conflictPolicy ?? ConflictPolicy.REUSE,
     };
   }
   return action;

--- a/src/test.ts
+++ b/src/test.ts
@@ -242,6 +242,7 @@ export function createMockStoreV6<S, A extends DecoratedActions, P = {}, DS = {}
       const newPropsRef = createRef({ ...propsRef.current, ...newProps });
       const derivedStateRef = createRef<DerivedState<DS>>({ state: null, deps: {} });
       const actionsRef = getActionsRef(actions as any, mockActions);
+
       const setState: SetStateFunc<S, A> = (newStateIn, _newLoadingMap, _actionName, _actionType, _isAsync) => {
         if (newStateIn != null) {
           newStateRef.current = newStateIn;

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,9 +148,15 @@ export type ContextBase<S, P> = ContextState<S> & {
 
 export type ContextWithDerived<S, DS, P> = ContextBase<S, P> & ContextDerivedStateState<DS>;
 
-export type InvocationContextActions<A> = {
+export type InvocationContextActions<S, A> = {
   actions: A;
   a: A;
+  /**
+   * The state injected in function will probably be incorrect after calling store actions.
+   * You can get the current state using this function.
+   * @returns the current state
+   */
+  getState: () => S;
 };
 
 export type WarningNotifyFunc = {
@@ -167,7 +173,10 @@ export type EffectsInvocationContext<S, DS, F extends (...args: any[]) => any, P
   res: PromiseResult<ReturnType<F>>;
 };
 
-export type GetPromiseInvocationContext<S, DS, F extends (...args: any[]) => any, P, A> = InvocationContextActions<A> &
+export type GetPromiseInvocationContext<S, DS, F extends (...args: any[]) => any, P, A> = InvocationContextActions<
+  S,
+  A
+> &
   InvocationContext<S, DS, F, P> & {
     abortSignal: AbortSignal;
   };
@@ -207,7 +216,7 @@ export type SideEffectsInvocationContext<S, DS, F extends (...args: any[]) => an
   F,
   P
 > &
-  InvocationContextActions<A> &
+  InvocationContextActions<S, A> &
   WarningNotifyFunc &
   ClearError<A>;
 
@@ -217,9 +226,9 @@ export type ErrorSideEffectsInvocationContext<
   F extends (...args: any[]) => any,
   P,
   A
-> = ErrorEffectsInvocationContext<S, DS, F, P> & InvocationContextActions<A> & WarningNotifyFunc;
+> = ErrorEffectsInvocationContext<S, DS, F, P> & InvocationContextActions<S, A> & WarningNotifyFunc;
 
-export type OnMountInvocationContext<S, A, P> = ContextBase<S, P> & InvocationContextActions<A>;
+export type OnMountInvocationContext<S, A, P> = ContextBase<S, P> & InvocationContextActions<S, A>;
 export type AbortedActions<A> = Partial<Record<keyof A, string[]>>;
 export type OnUnMountInvocationContext<S, A, P> = ContextBase<S, P> & { abortedActions: AbortedActions<A> };
 

--- a/src/v5_test.ts
+++ b/src/v5_test.ts
@@ -229,6 +229,7 @@ export function testV6AdvancedSyncAction<S, F extends (...args: any[]) => any, A
           res: null,
           result: null,
           promiseId: null,
+          getState: () => null,
           clearError: () => {},
         });
       },
@@ -273,6 +274,7 @@ export function testV6AsyncAction<S, F extends (...args: any[]) => any, A, P>(
             state: s,
             props: p,
             actions: a,
+            getState: () => null,
             promiseId: null,
           });
         }
@@ -287,6 +289,7 @@ export function testV6AsyncAction<S, F extends (...args: any[]) => any, A, P>(
           state: s,
           props: p,
           actions: a,
+          getState: () => null,
           promiseId: null,
         });
       },
@@ -304,6 +307,7 @@ export function testV6AsyncAction<S, F extends (...args: any[]) => any, A, P>(
             state: s,
             props: p,
             actions: a,
+            getState: () => null,
             promiseId: null,
           });
         }
@@ -396,6 +400,7 @@ export function testV6AsyncAction<S, F extends (...args: any[]) => any, A, P>(
           actions: a,
           result: res,
           promiseId: actionIn.getPromiseId?.(...args),
+          getState: () => null,
           clearError: () => {},
         });
       },
@@ -414,6 +419,7 @@ export function testV6AsyncAction<S, F extends (...args: any[]) => any, A, P>(
           props: p,
           actions: a,
           error: err,
+          getState: () => null,
           promiseId: actionIn.getPromiseId?.(...args),
         });
       },

--- a/tests/Hooks.test.tsx
+++ b/tests/Hooks.test.tsx
@@ -19,7 +19,7 @@ import {
 import { getTimeoutPromise } from './utils';
 
 type State = {
-  prop1: string;
+  stateProp1: string;
 };
 
 type Actions = {
@@ -29,18 +29,19 @@ type Actions = {
 
 type Props = {
   prop1: string;
+  prop2?: string;
 };
 
 const actionsImpl: StoreActions<State, Actions, Props> = {
-  setProp1: ({ args: [p] }) => ({ prop1: p }),
+  setProp1: ({ args: [p] }) => ({ stateProp1: p }),
   setAsyncProp1: {
     getPromise: () => getTimeoutPromise(100, 'ok'),
-    effects: ({ args: [p] }) => ({ prop1: p }),
+    effects: ({ args: [p] }) => ({ stateProp1: p }),
   },
 };
 
 const getInitialState = (p: Props): State => ({
-  prop1: p?.prop1 ?? '',
+  stateProp1: p?.prop1 ?? '',
 });
 
 type StoreContextProps = StoreApi<State, Actions, Props>;
@@ -55,18 +56,20 @@ function StoreContextProvider(p: { children: any }) {
 describe('react hooks', () => {
   it('useLocalStore works as expected', () => {
     const { result } = renderHook(() => useLocalStore({ getInitialState, actions: actionsImpl }));
-    expect(result.current.state).toEqual({ prop1: '' });
+    expect(result.current.state).toEqual({ stateProp1: '' });
     act(() => {
       result.current.actions.setProp1('v1');
     });
-    expect(result.current.state).toEqual({ prop1: 'v1' });
+    expect(result.current.state).toEqual({ stateProp1: 'v1' });
   });
 
   it('useLocalStore works as expected', () => {
     const callback = jest.fn();
     const callback2 = jest.fn();
 
-    const options: StoreOptions<State, Actions> = {
+    const storeConfig: StoreConfig<State, Actions, Props> = {
+      getInitialState,
+      actions: actionsImpl,
       onMountDeferred: () => {
         callback();
       },
@@ -79,12 +82,12 @@ describe('react hooks', () => {
       },
     };
 
-    const { result } = renderHook(() => useLocalStore({ getInitialState, actions: actionsImpl, ...options }));
-    expect(result.current.state).toEqual({ prop1: '' });
+    const { result } = renderHook(() => useLocalStore(storeConfig, { prop1: '' }));
+    expect(result.current.state).toEqual({ stateProp1: '' });
     act(() => {
       result.current.actions.setProp1('v1');
     });
-    expect(result.current.state).toEqual({ prop1: 'v1' });
+    expect(result.current.state).toEqual({ stateProp1: 'v1' });
     expect(callback).toHaveBeenCalled();
     expect(callback2).toHaveBeenCalled();
 
@@ -95,13 +98,13 @@ describe('react hooks', () => {
 
   it('useStore works as expected', () => {
     const store = createStore({ getInitialState, actions: actionsImpl });
-    store.init({});
+    store.init({ prop1: '' });
     const { result } = renderHook(() => useStore(store));
-    expect(store.state.prop1).toEqual('');
+    expect(store.state.stateProp1).toEqual('');
     act(() => {
       store.actions.setProp1('v1');
     });
-    expect(store.state.prop1).toEqual('v1');
+    expect(store.state.stateProp1).toEqual('v1');
   });
 
   it('useBindStore works as expected', () => {
@@ -110,7 +113,7 @@ describe('react hooks', () => {
       actions: actionsImpl,
       onPropsChange: {
         getDeps: (p) => [p.prop1],
-        effects: ({ p }) => ({ prop1: p.prop1 }),
+        effects: ({ p }) => ({ stateProp1: p.prop1 }),
       },
     };
     const store = createStore(storeConfig);
@@ -120,31 +123,33 @@ describe('react hooks', () => {
         prop1: 'initial',
       },
     });
-    expect(store.state.prop1).toEqual('initial');
+    expect(store.state.stateProp1).toEqual('initial');
 
     act(() => {
       store.actions.setProp1('v1');
     });
-    expect(store.state.prop1).toEqual('v1');
+    expect(store.state.stateProp1).toEqual('v1');
 
     rerender({ prop1: 'other' });
-    expect(store.state.prop1).toEqual('other');
+    expect(store.state.stateProp1).toEqual('other');
   });
 
   it('useStoreSlice works as expected (props)', () => {
     const store = createStore({ getInitialState, actions: actionsImpl });
     // parent hook will init the store
-    store.init({ prop1: '' });
+    store.init({ prop1: '', prop2: 'prop2' });
 
-    const { result } = renderHook(() => useStoreSlice(store, ['prop1', 'setProp1']));
+    const { result } = renderHook(() => useStoreSlice(store, ['stateProp1', 'setProp1', 'prop2']));
 
-    expect(result.current.prop1).toEqual('');
+    expect(result.current.stateProp1).toEqual('');
+    expect(result.current.prop2).toEqual('prop2');
 
     act(() => {
       result.current.setProp1('v1');
     });
 
-    expect(result.current.prop1).toEqual('v1');
+    expect(result.current.stateProp1).toEqual('v1');
+    expect(result.current.prop2).toEqual('prop2');
   });
 
   it('useStoreSlice works as expected (func)', () => {
@@ -154,7 +159,7 @@ describe('react hooks', () => {
 
     const { result } = renderHook(() =>
       useStoreSlice(store, (ctx) => ({
-        res: ctx.prop1,
+        res: ctx.stateProp1,
         set: ctx.setProp1,
       }))
     );
@@ -174,7 +179,7 @@ describe('react hooks', () => {
     const { result } = renderHook(
       () =>
         useStoreContextSlice(StoreContext, (ctx) => ({
-          res: ctx.prop1,
+          res: ctx.stateProp1,
           set: ctx.setProp1,
         })),
       { wrapper }
@@ -192,14 +197,14 @@ describe('react hooks', () => {
   it('useStoreContextSlice works as expected (props)', () => {
     const wrapper = ({ children }) => <StoreContextProvider>{children}</StoreContextProvider>;
 
-    const { result } = renderHook(() => useStoreContextSlice(StoreContext, ['prop1', 'setProp1']), { wrapper });
+    const { result } = renderHook(() => useStoreContextSlice(StoreContext, ['stateProp1', 'setProp1']), { wrapper });
 
-    expect(result.current.prop1).toEqual('');
+    expect(result.current.stateProp1).toEqual('');
 
     act(() => {
       result.current.setProp1('v1');
     });
 
-    expect(result.current.prop1).toEqual('v1');
+    expect(result.current.stateProp1).toEqual('v1');
   });
 });


### PR DESCRIPTION
In a getPromise or a sideEffects function, one can call actions of the store.
These actions will probably change the state.
if we need to reuse the updated state, currently we must return the new value as the promise result.
This is not convenient as it's cleaner to process the object in the effects than in the getPromise. 
The implemented solution in this PR is to add a getState function in the context that allows to get the current state.

Problem: allow to unit test actions using getState