### PR TITLE
feat: state listener optims

### DIFF
--- a/samples/src/App.tsx
+++ b/samples/src/App.tsx
@@ -20,6 +20,7 @@ import Abort from './Abort';
 
 import PropsChangeOnMount from './PropsChangeOnMount';
 import DeferOnMount from './DeferOnMount';
+import { OptimRefresh } from './OptimRefresh';
 
 type TabPanelProps = {
   children?: ReactNode;
@@ -81,6 +82,7 @@ export default function App() {
           <Tab label="Error" />
           <Tab label="Recipes" />
           <Tab label="Defer onMount" />
+          <Tab label="Optim" />
         </Tabs>
         <Box flex={1} className={classes.content}>
           <TabPanel tabId={tabId} index={0}>
@@ -119,6 +121,9 @@ export default function App() {
           </TabPanel>
           <TabPanel tabId={tabId} index={11}>
             <DeferOnMount />
+          </TabPanel>
+          <TabPanel tabId={tabId} index={12}>
+            <OptimRefresh />
           </TabPanel>
         </Box>
       </Paper>

--- a/samples/src/OptimRefresh.tsx
+++ b/samples/src/OptimRefresh.tsx
@@ -1,0 +1,59 @@
+import { useRef } from 'react';
+import useLocalStore, { StoreConfig, LoadingProps } from './sd_src/index';
+import useLogger from './useLogger';
+
+// TYPES ===============================
+
+type OptimRefreshProps = {};
+type Props = {};
+type State = {
+  v: number;
+};
+type Actions = {
+  a1: () => Promise<number>;
+  a2: () => Promise<number>;
+};
+
+const storeConfig: StoreConfig<State, Actions, Props> = {
+  initialState: {
+    v: 1,
+  },
+  actions: {
+    a1: {
+      getPromise: () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(10), 2000);
+        }),
+      sideEffects: ({ a }) => {
+        a.a2();
+      },
+    },
+    a2: {
+      getPromise: () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(20), 3000);
+        }),
+      effects: ({ res }) => ({ v: res }),
+    },
+  },
+  onMount: ({ a }) => {
+    a.a1();
+  },
+};
+
+// VIEW ================================
+
+export type OptimRefreshViewProps = State & Actions & Pick<LoadingProps<Actions>, 'loadingMap'>;
+
+export function OptimRefreshView(p: OptimRefreshViewProps) {
+  useLogger('compo', p);
+
+  return <div>See console</div>;
+}
+
+// CONTAINER ===========================
+
+export function OptimRefresh(p: OptimRefreshProps) {
+  const { state: s, actions: a, loadingMap } = useLocalStore(storeConfig, p);
+  return <OptimRefreshView {...p} {...s} {...a} loadingMap={loadingMap} />;
+}

--- a/samples/src/OptimRefresh.tsx
+++ b/samples/src/OptimRefresh.tsx
@@ -1,6 +1,6 @@
-import { useRef } from 'react';
 import useLocalStore, { StoreConfig, LoadingProps } from './sd_src/index';
 import useLogger from './useLogger';
+import Button from '@mui/material/Button';
 
 // TYPES ===============================
 
@@ -12,6 +12,9 @@ type State = {
 type Actions = {
   a1: () => Promise<number>;
   a2: () => Promise<number>;
+  a3: () => void;
+  a4: () => void;
+  a5: () => void;
 };
 
 const storeConfig: StoreConfig<State, Actions, Props> = {
@@ -24,6 +27,7 @@ const storeConfig: StoreConfig<State, Actions, Props> = {
         new Promise((resolve) => {
           setTimeout(() => resolve(10), 2000);
         }),
+      effects: () => ({ v: 99 }),
       sideEffects: ({ a }) => {
         a.a2();
       },
@@ -35,9 +39,22 @@ const storeConfig: StoreConfig<State, Actions, Props> = {
         }),
       effects: ({ res }) => ({ v: res }),
     },
-  },
-  onMount: ({ a }) => {
-    a.a1();
+    a3: {
+      effects: () => ({ v: 66 }),
+      sideEffects: ({ a }) => {
+        a.a1();
+      },
+    },
+    a4: {
+      debounceSideEffectsTimeout: 1000,
+      effects: () => {
+        return { v: 44 };
+      },
+      sideEffects: ({ a }) => {
+        a.a1();
+      },
+    },
+    a5: { effects: () => ({ v: 22 }) },
   },
 };
 
@@ -46,9 +63,33 @@ const storeConfig: StoreConfig<State, Actions, Props> = {
 export type OptimRefreshViewProps = State & Actions & Pick<LoadingProps<Actions>, 'loadingMap'>;
 
 export function OptimRefreshView(p: OptimRefreshViewProps) {
-  useLogger('compo', p);
+  useLogger('OptimRefresh', p);
 
-  return <div>See console</div>;
+  return (
+    <div>
+      <div>
+        <div>A1: Async, call A2</div>
+        <div>A2: Async</div>
+        <div>A3: Sync call A1 as side effect</div>
+        <div>A4: Sync call A1 as side effect with debounce</div>
+        <div>A5: Sync no side effect</div>
+      </div>
+      <br />
+      {([1, 2, 3, 4, 5] as const).map((x) => (
+        <Button
+          key={x}
+          variant="outlined"
+          onClick={() => {
+            p[`a${x}`]();
+          }}
+        >
+          Launch action A{x}
+        </Button>
+      ))}
+
+      <div>See console</div>
+    </div>
+  );
 }
 
 // CONTAINER ===========================

--- a/samples/src/useLogger.ts
+++ b/samples/src/useLogger.ts
@@ -1,0 +1,56 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Hook personnalisé pour suivre pourquoi un composant React est rendu
+ * @param {string} componentName - Nom du composant (pour faciliter l'identification dans la console)
+ * @param {Object} props - Props du composant
+ * @param {Array} dependencies - Tableau de dépendances à surveiller (comme pour useEffect)
+ * @param {Object} state - État du composant à surveiller (optionnel)
+ */
+const useLogger = (componentName: string, props: Object) => {
+  // Référence aux props et état précédents
+  const prevPropsRef = useRef(props);
+  const renderCountRef = useRef(0);
+
+  useEffect(() => {
+    // Premier rendu
+    if (renderCountRef.current === 0) {
+      console.log(`[${componentName}] Premier rendu`);
+      renderCountRef.current++;
+      prevPropsRef.current = props;
+      return;
+    }
+
+    // Incrémenter le compteur de rendu
+    renderCountRef.current++;
+
+    // Vérifier les changements dans les props
+    const prevProps = prevPropsRef.current;
+    const propsChanges = Object.keys(props).filter((key) => prevProps[key] !== props[key]);
+
+    if (propsChanges.length > 0) {
+      console.log(
+        `[${componentName}] Rendu #${renderCountRef.current} causé par changement de props:`,
+        propsChanges.reduce((acc, key) => {
+          acc[key] = {
+            de: prevProps[key],
+            vers: props[key],
+          };
+          return acc;
+        }, {})
+      );
+    }
+
+    // Si aucun changement détecté mais composant rendu quand même
+    if (propsChanges.length === 0) {
+      console.log(
+        `[${componentName}] Rendu #${renderCountRef.current} - Aucun changement détecté, possible rendu parent`
+      );
+    }
+
+    // Mettre à jour les références
+    prevPropsRef.current = props;
+  });
+};
+
+export default useLogger;

--- a/samples/src/useLogger.ts
+++ b/samples/src/useLogger.ts
@@ -7,9 +7,9 @@ import { useRef, useEffect } from 'react';
  * @param {Array} dependencies - Tableau de dépendances à surveiller (comme pour useEffect)
  * @param {Object} state - État du composant à surveiller (optionnel)
  */
-const useLogger = (componentName: string, props: Object) => {
+const useLogger = (componentName: string, props: Record<string, any>) => {
   // Référence aux props et état précédents
-  const prevPropsRef = useRef(props);
+  const prevPropsRef = useRef<any>(props);
   const renderCountRef = useRef(0);
 
   useEffect(() => {
@@ -31,7 +31,7 @@ const useLogger = (componentName: string, props: Object) => {
     if (propsChanges.length > 0) {
       console.log(
         `[${componentName}] Rendu #${renderCountRef.current} causé par changement de props:`,
-        propsChanges.reduce((acc, key) => {
+        propsChanges.reduce<Record<string, any>>((acc, key) => {
           acc[key] = {
             de: prevProps[key],
             vers: props[key],

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -919,8 +919,6 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
     );
   }
 
-  console.log(actionName, 'processPromiseSuccess > stateFlagRef.current', stateFlagRef.current);
-
   if (!stateFlagRef.current) {
     notifyStateListeners();
   }

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -61,8 +61,9 @@ export type SetStateFunc<S, A> = (
   isAsync: boolean,
   actionCtx: any,
   propsChanged: boolean,
-  isInit?: boolean
-) => void;
+  isInit?: boolean,
+  disableNotify?: boolean
+) => () => void;
 
 /** @internal */
 export type PromiseMap<A> = {
@@ -101,6 +102,7 @@ export type AsyncActionExecContext<S, DS, F extends (...args: any[]) => any, A e
   conflictActionsRef: Ref<ConflictActionsMap<A>>;
   actionsRef: Ref<A>;
   initializedRef: Ref<boolean>;
+  stateFlagRef: Ref<boolean>;
   timeoutRef: Ref<TimeoutMap<A>>;
   options: StoreOptions<S, A, P, any>;
   setState: SetStateFunc<S, A>;
@@ -851,6 +853,7 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
   const {
     action,
     stateRef,
+    stateFlagRef,
     derivedStateRef,
     propsRef,
     promisesRef,
@@ -880,14 +883,18 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
     }
   }
 
-  setState(
+  stateFlagRef.current = false;
+
+  const notifyStateListeners = setState(
     newState,
     buildLoadingMap(loadingMapRef.current, actionName, promiseId, false),
     actionName,
     'effects',
     true,
     ctx,
-    false
+    false,
+    false,
+    true
   );
 
   const notifySuccess = options.notifySuccess || globalConfig.notifySuccess;
@@ -910,6 +917,12 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
     action.sideEffects(
       addSideEffectsContext(ctx, stateRef, derivedStateRef, actionsRef, globalConfig.notifyWarning, clearError)
     );
+  }
+
+  console.log(actionName, 'processPromiseSuccess > stateFlagRef.current', stateFlagRef.current);
+
+  if (!stateFlagRef.current) {
+    notifyStateListeners();
   }
 
   processNextConflictAction(context.initializedRef, actionName, actionsRef.current, conflictActionsRef.current);

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -102,7 +102,7 @@ export type AsyncActionExecContext<S, DS, F extends (...args: any[]) => any, A e
   conflictActionsRef: Ref<ConflictActionsMap<A>>;
   actionsRef: Ref<A>;
   initializedRef: Ref<boolean>;
-  stateFlagRef: Ref<boolean>;
+  needNotifyListenersRef: Ref<boolean>;
   timeoutRef: Ref<TimeoutMap<A>>;
   options: StoreOptions<S, A, P, any>;
   setState: SetStateFunc<S, A>;
@@ -734,6 +734,7 @@ function executeSyncActionImpl<S, DS, F extends (...args: any[]) => any, A exten
   actionsRef: Ref<A>,
   timeoutMap: Ref<TimeoutMap<A>>,
   initializedRef: Ref<boolean>,
+  needNotifyListenersRef: Ref<boolean>,
   options: StoreOptions<S, A, P, any>,
   setState: SetStateFunc<S, A>,
   clearError: ClearErrorFunc<A>,
@@ -741,13 +742,28 @@ function executeSyncActionImpl<S, DS, F extends (...args: any[]) => any, A exten
 ) {
   const ctx = buildEffectsInvocationContext(stateRef, derivedStateRef, propsRef, args, undefined);
 
+  let notifyStateListeners;
   let actionDropped = false;
   if (action.effects != null) {
     const newState: S = mergeState(stateRef, action.effects(ctx), options.fullStateEffects);
     if (newState === null) {
       actionDropped = true;
     } else {
-      setState(newState, undefined, actionName, 'effects', false, ctx, false);
+      const mustNotifyNow = action.debounceSideEffectsTimeout != null || action.sideEffects == null;
+
+      needNotifyListenersRef.current = !mustNotifyNow;
+
+      notifyStateListeners = setState(
+        newState,
+        undefined,
+        actionName,
+        'effects',
+        false,
+        ctx,
+        false,
+        false,
+        !mustNotifyNow
+      );
     }
   }
 
@@ -768,10 +784,16 @@ function executeSyncActionImpl<S, DS, F extends (...args: any[]) => any, A exten
         );
         delete timeoutMap.current[actionName];
       }, action.debounceSideEffectsTimeout);
+
+      // no need to call notifyStateListeners
     } else {
       action.sideEffects?.(
         addSideEffectsContext(ctx, stateRef, derivedStateRef, actionsRef, options.notifyWarning, clearError)
       );
+
+      if (needNotifyListenersRef.current) {
+        notifyStateListeners?.();
+      }
     }
   }
 }
@@ -786,6 +808,7 @@ export function decorateSyncAction<S, DS, F extends (...args: any[]) => any, A e
   actionsRef: Ref<A>,
   initializedRef: Ref<boolean>,
   timeoutMap: Ref<TimeoutMap<A>>,
+  needNotifyListenersRef: Ref<boolean>,
   options: StoreOptions<S, A, P, any>,
   setState: SetStateFunc<S, A>,
   clearError: ClearErrorFunc<A>
@@ -819,6 +842,7 @@ export function decorateSyncAction<S, DS, F extends (...args: any[]) => any, A e
           actionsRef,
           timeoutMap,
           initializedRef,
+          needNotifyListenersRef,
           options,
           setState,
           clearError,
@@ -835,6 +859,7 @@ export function decorateSyncAction<S, DS, F extends (...args: any[]) => any, A e
         actionsRef,
         timeoutMap,
         initializedRef,
+        needNotifyListenersRef,
         options,
         setState,
         clearError,
@@ -853,7 +878,7 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
   const {
     action,
     stateRef,
-    stateFlagRef,
+    needNotifyListenersRef,
     derivedStateRef,
     propsRef,
     promisesRef,
@@ -883,7 +908,7 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
     }
   }
 
-  stateFlagRef.current = false;
+  needNotifyListenersRef.current = true;
 
   const notifyStateListeners = setState(
     newState,
@@ -919,7 +944,7 @@ function processPromiseSuccess<S, DS, F extends (...args: any[]) => any, A exten
     );
   }
 
-  if (!stateFlagRef.current) {
+  if (needNotifyListenersRef.current) {
     notifyStateListeners();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,8 +267,6 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
   function notifyStateListeners() {
     updateSnapshot();
 
-    console.log('notifyStateListeners');
-
     Object.keys(stateListeners).forEach((listenerId) => {
       // listeners can be removed while calling updates (!)
       stateListeners[listenerId]?.();

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,6 +244,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
   const promisesRef = createRef<PromiseMap<A>>();
   const conflictActionsRef = createRef<ConflictActionsMap<A>>();
   const initializedRef = createRef(false);
+  const stateFlagRef = createRef(false);
   const snapshotRef = createRef<StateListenerContext<S, DS, A, P>>();
 
   const middlewaresRef = createRef<Middleware<S, A, P>[]>([]);
@@ -265,6 +266,8 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
 
   function notifyStateListeners() {
     updateSnapshot();
+
+    console.log('notifyStateListeners');
 
     Object.keys(stateListeners).forEach((listenerId) => {
       // listeners can be removed while calling updates (!)
@@ -473,12 +476,13 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
     isAsync: boolean,
     actionCtx: any,
     propsChanged: boolean = false,
-    init = false
+    init = false,
+    preventNotify = false
   ) {
     let hasChanged = false;
 
     if (!initializedRef.current) {
-      return;
+      return notifyStateListeners;
     }
 
     let newLoadingMap = newLoadingMapIn;
@@ -525,14 +529,20 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
       computeDerivedValues(stateRef, propsRef, derivedStateRef, options);
       if (!init) {
         stateRef.current = newState || stateRef.current;
-        notifyStateListeners();
+        if (!preventNotify) {
+          stateFlagRef.current = true;
+          notifyStateListeners();
+        }
       }
     } else if (propsChanged) {
       const derivedChanged = computeDerivedValues(stateRef, propsRef, derivedStateRef, options);
-      if (derivedChanged && !init) {
+      if (derivedChanged && !init && !preventNotify) {
+        stateFlagRef.current = true;
         notifyStateListeners();
       }
     }
+
+    return notifyStateListeners;
   }
 
   const keys = Object.keys(actionsImpl) as (keyof A)[];
@@ -562,6 +572,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
         conflictActionsRef,
         initializedRef,
         timeoutRef,
+        stateFlagRef,
         options,
         setState,
         clearError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
   const promisesRef = createRef<PromiseMap<A>>();
   const conflictActionsRef = createRef<ConflictActionsMap<A>>();
   const initializedRef = createRef(false);
-  const stateFlagRef = createRef(false);
+  const needNotifyListenersRef = createRef(false);
   const snapshotRef = createRef<StateListenerContext<S, DS, A, P>>();
 
   const middlewaresRef = createRef<Middleware<S, A, P>[]>([]);
@@ -266,6 +266,8 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
 
   function notifyStateListeners() {
     updateSnapshot();
+
+    needNotifyListenersRef.current = false;
 
     Object.keys(stateListeners).forEach((listenerId) => {
       // listeners can be removed while calling updates (!)
@@ -528,14 +530,12 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
       if (!init) {
         stateRef.current = newState || stateRef.current;
         if (!preventNotify) {
-          stateFlagRef.current = true;
           notifyStateListeners();
         }
       }
     } else if (propsChanged) {
       const derivedChanged = computeDerivedValues(stateRef, propsRef, derivedStateRef, options);
       if (derivedChanged && !init && !preventNotify) {
-        stateFlagRef.current = true;
         notifyStateListeners();
       }
     }
@@ -570,7 +570,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
         conflictActionsRef,
         initializedRef,
         timeoutRef,
-        stateFlagRef,
+        needNotifyListenersRef,
         options,
         setState,
         clearError,
@@ -586,6 +586,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
         actionsRef,
         initializedRef,
         timeoutRef,
+        needNotifyListenersRef,
         options,
         setState,
         clearError

--- a/src/test.ts
+++ b/src/test.ts
@@ -252,6 +252,7 @@ export function createMockStoreV6<S, A extends DecoratedActions, P = {}, DS = {}
         if (newStateIn != null) {
           newStateRef.current = newStateIn;
         }
+        return () => {};
       };
 
       const res = this.onPropsChangeImpl(
@@ -317,6 +318,7 @@ export function createMockStoreV6<S, A extends DecoratedActions, P = {}, DS = {}
         if (newStateIn != null) {
           newStateRef.current = newStateIn;
         }
+        return () => {};
       };
 
       // sync
@@ -494,6 +496,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
     },
     call(...args) {
       const newStateRef = createRef<S>({ ...stateRef.current });
+      const stateFlagRef = createRef<boolean>(false);
       const derivedStateRef = createRef<DerivedState<DS>>({ state: null, deps: {} });
       computeDerivedValues(newStateRef, propsRef, derivedStateRef, options, derivedStateOverrideRef);
 
@@ -513,6 +516,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
         if (newStateIn != null) {
           newStateRef.current = newStateIn;
         }
+        return () => {};
       };
 
       const action = actions[actionName];
@@ -589,6 +593,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
             conflictActionsRef,
             initializedRef,
             timeoutRef: createRef({}),
+            stateFlagRef,
             options,
             setState,
             stateRef: newStateRef,

--- a/src/test.ts
+++ b/src/test.ts
@@ -496,7 +496,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
     },
     call(...args) {
       const newStateRef = createRef<S>({ ...stateRef.current });
-      const stateFlagRef = createRef<boolean>(false);
+      const needNotifyListenersRef = createRef<boolean>(false);
       const derivedStateRef = createRef<DerivedState<DS>>({ state: null, deps: {} });
       computeDerivedValues(newStateRef, propsRef, derivedStateRef, options, derivedStateOverrideRef);
 
@@ -547,6 +547,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
           actionsRef as any,
           createRef(true),
           null,
+          createRef(false),
           options,
           setState,
           (_: keyof A) => {}
@@ -593,7 +594,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
             conflictActionsRef,
             initializedRef,
             timeoutRef: createRef({}),
-            stateFlagRef,
+            needNotifyListenersRef,
             options,
             setState,
             stateRef: newStateRef,

--- a/tests/AsyncActions.test.ts
+++ b/tests/AsyncActions.test.ts
@@ -307,9 +307,7 @@ describe('Async action', () => {
       notifyError,
     });
 
-    const listener = jest.fn(() => {
-      console.log(store.state, store.loadingMap.successActionWithSideEffect, store.loadingMap.successAction);
-    });
+    const listener = jest.fn();
 
     store.addStateListener(listener);
     store.setProps({

--- a/tests/AsyncActions.test.ts
+++ b/tests/AsyncActions.test.ts
@@ -32,6 +32,7 @@ describe('Async action', () => {
 
   type Actions = {
     successAction: (p: string) => Promise<string>;
+    successActionWithSideEffect: (p: string) => Promise<string>;
     errorAction: (p: string) => Promise<any>;
     errorActionGetErrorMsg: (p: string) => Promise<any>;
     errorActionDefaultErrorMsg: (p: string) => Promise<any>;
@@ -56,10 +57,10 @@ describe('Async action', () => {
   };
 
   const baseAction: StoreAction<State, Actions['successAction'], Actions, Props> = {
-    preEffects: ({ s }) => ({ prop1: 'pre' }),
+    preEffects: () => ({ prop1: 'pre' }),
     getPromise: () => Promise.resolve('resolved'),
-    effects: ({ s, res: prop1, args: [prop2] }) => ({ prop1, prop2 }),
-    errorEffects: ({ s, err }) => ({ error: err.message }),
+    effects: ({ res: prop1, args: [prop2] }) => ({ prop1, prop2 }),
+    errorEffects: ({ err }) => ({ error: err.message }),
     sideEffects: ({ s, p }) => {
       p.callback('onDone', s);
     },
@@ -72,6 +73,12 @@ describe('Async action', () => {
 
   const actionsImpl: StoreActions<State, Actions, Props> = {
     successAction: { ...baseAction },
+    successActionWithSideEffect: {
+      ...baseAction,
+      sideEffects: ({ a, args: [p] }) => {
+        a.successAction(p + '_side');
+      },
+    },
     errorAction: {
       ...baseAction,
       getPromise: () => Promise.reject(new Error('failed!')),
@@ -273,6 +280,66 @@ describe('Async action', () => {
     expect(isLoading('successAction')).toBeTruthy();
     expect(store.loading).toBeTruthy();
     expect(store.loadingMap.successAction).toBeTruthy();
+
+    return promise;
+  });
+
+  it('action in sideEffects - do not trigger too many notifyStateListeners', () => {
+    const callback = jest.fn();
+    const callbackError = jest.fn();
+    const callbackCancel = jest.fn();
+    const notifySuccess = jest.fn();
+    const notifyError = jest.fn();
+
+    const actions: StoreActions<State, Actions, Props> = {
+      ...actionsImpl,
+      successAction: {
+        getPromise: () => Promise.resolve('resolved'),
+        effects: ({ res: prop1, args: [prop2] }) => ({ prop1, prop2 }),
+        errorEffects: ({ err }) => ({ error: err.message }),
+      },
+    };
+
+    const store = createStore({
+      getInitialState,
+      actions,
+      notifySuccess,
+      notifyError,
+    });
+
+    const listener = jest.fn(() => {
+      console.log(store.state, store.loadingMap.successActionWithSideEffect, store.loadingMap.successAction);
+    });
+
+    store.addStateListener(listener);
+    store.setProps({
+      callback,
+      callbackError,
+      callbackCancel,
+    });
+
+    const { isLoading } = store;
+
+    const promise = store.actions.successActionWithSideEffect('result');
+
+    promise.then(() => {
+      // call 1 => init
+      // call 2 => 1st action load
+      // call 3 => 2nd action load
+      // call 4 => effect of 2nd action
+      expect(listener).toHaveBeenCalledTimes(4);
+      expect(notifyError).not.toHaveBeenCalled();
+
+      expect(store.state).toEqual({
+        prop1: 'resolved',
+        prop2: 'result_side',
+        error: '',
+      });
+
+      expect(callbackCancel).not.toHaveBeenCalled();
+
+      expect(isLoading('successAction')).toBeFalsy();
+    });
 
     return promise;
   });

--- a/tests/SyncActions.test.ts
+++ b/tests/SyncActions.test.ts
@@ -33,7 +33,7 @@ describe('Advanced synchronous action', () => {
     },
     sideEffects: {
       sideEffects: ({ s, p }) => {
-        p.callbackSideEffects(s);
+        p.callbackSideEffects?.(s);
       },
     },
     setEffectsDebounced: {
@@ -132,6 +132,116 @@ describe('Advanced synchronous action', () => {
       prop1: 'coucou',
       prop2: 23,
     });
+  });
+
+  it('action in sideEffects - do not trigger too many notifyStateListeners', () => {
+    const callback = jest.fn();
+    const callbackSideEffects = jest.fn();
+    const callbackCancelled = jest.fn();
+    const notifySuccess = jest.fn();
+    const notifyError = jest.fn();
+
+    const actionsImpl: StoreActions<State, Actions, Props> = {
+      ...actions,
+      setProp2: {
+        effects: ({ args: [p] }) => ({ prop2: p }),
+        sideEffects: ({ s, a }) => {
+          a.setProp1(`sideEffect ${s.prop2}`);
+        },
+      },
+    };
+
+    const store = createStore({
+      getInitialState,
+      actions: actionsImpl,
+      notifySuccess,
+      notifyError,
+    });
+
+    const listener = jest.fn();
+
+    store.addStateListener(listener);
+    store.setProps({
+      callback,
+      callbackCancelled,
+      callbackSideEffects,
+    });
+
+    store.actions.setProp2(12);
+
+    // call 1 => init
+    // call 2 => 1st + 2nd action effects
+
+    // non optim would be:
+    // call 1 => init
+    // call 2 => 1st effects
+    // call 3 => 2nd effects
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(notifyError).not.toHaveBeenCalled();
+
+    expect(store.state).toEqual({
+      prop1: `sideEffect 12`,
+      prop2: 12,
+    });
+
+    expect(callbackCancelled).not.toHaveBeenCalled();
+  });
+
+  it('action in sideEffects - no optim if debounced side effects', (done) => {
+    const callback = jest.fn();
+    const callbackSideEffects = jest.fn();
+    const callbackCancelled = jest.fn();
+    const notifySuccess = jest.fn();
+    const notifyError = jest.fn();
+
+    const actionsImpl: StoreActions<State, Actions, Props> = {
+      ...actions,
+      setProp1: {
+        effects: ({ args: [p] }) => ({ prop1: p }),
+      },
+      setProp2: {
+        effects: ({ args: [p] }) => ({ prop2: p }),
+        sideEffects: ({ s, a }) => {
+          a.setProp1(`sideEffect ${s.prop2}`);
+        },
+        debounceSideEffectsTimeout: 50,
+      },
+    };
+
+    const store = createStore({
+      getInitialState,
+      actions: actionsImpl,
+      notifySuccess,
+      notifyError,
+    });
+
+    const listener = jest.fn(() => {});
+
+    store.addStateListener(listener);
+    store.setProps({
+      callback,
+      callbackCancelled,
+      callbackSideEffects,
+    });
+
+    store.actions.setProp2(12);
+
+    setTimeout(() => {
+      // call 1 => init
+      // call 2 => 1st effects - cannot optimize !
+      // call 3 => 2nd effects
+      expect(listener).toHaveBeenCalledTimes(3);
+
+      expect(notifyError).not.toHaveBeenCalled();
+
+      expect(store.state).toEqual({
+        prop1: `sideEffect 12`,
+        prop2: 12,
+      });
+
+      expect(callbackCancelled).not.toHaveBeenCalled();
+      done();
+    }, 100);
   });
 
   it('debounced side effects', (done) => {

--- a/tests/Tests.test.ts
+++ b/tests/Tests.test.ts
@@ -44,7 +44,9 @@ describe('createMockStore', () => {
   };
 
   const actions: StoreActions<State, Actions, Props> = {
-    setProp1: ({ args: [v] }) => ({ prop1: v }),
+    setProp1: ({ args: [v] }) => {
+      return { prop1: v };
+    },
     setProp4: ({ args: [v] }) => ({ prop4: v }),
     setProp2: {
       effects: ({ args: [v] }) => ({ prop2: v }),


### PR DESCRIPTION
if another action is called in a side effect of an asynchronous action, the effects that contains the action effect + loading state will called and a fraction of time later the sub action effect resulting in some show / hide / show loading for example.
The new behavior is:
- at the end of the async action, set the state internally but do no notify
- call the side effects
- if the side effect has triggered a state change => the effects were already notified
- otherwise notify listeners