### PR TITLE
feat: add more tests to prevent crash on destroyed store

### DIFF
--- a/src/impl.ts
+++ b/src/impl.ts
@@ -101,6 +101,7 @@ export type AsyncActionExecContext<S, DS, F extends (...args: any[]) => any, A e
   conflictActionsRef: Ref<ConflictActionsMap<A>>;
   actionsRef: Ref<A>;
   initializedRef: Ref<boolean>;
+  timeoutRef: Ref<TimeoutMap<A>>;
   options: StoreOptions<S, A, P, any>;
   setState: SetStateFunc<S, A>;
   clearError: ClearErrorFunc<A>;
@@ -433,6 +434,7 @@ export function buildErrorMap<A>(map: ErrorParallelMap<A>) {
 /** @internal */
 export function retryPromiseDecorator<S, DS, F extends (...args: any[]) => Promise<any>, A, P>(
   promiseProvider: PromiseProvider<S, DS, F, A, P>,
+  registerTimeout: (timeoutId: ReturnType<typeof setTimeout>) => void,
   maxCalls = 1,
   delay = 1000,
   isRetryError: (e: Error) => boolean = () => true
@@ -452,12 +454,14 @@ export function retryPromiseDecorator<S, DS, F extends (...args: any[]) => Promi
             return Promise.reject(e);
           }
           return new Promise((resolve, reject) => {
-            setTimeout(() => {
-              const p = promiseProvider(ctx);
-              call(callCount + 1, p)
-                .then(resolve)
-                .catch(reject);
-            }, delay * callCount);
+            registerTimeout(
+              setTimeout(() => {
+                const p = promiseProvider(ctx);
+                call(callCount + 1, p)
+                  .then(resolve)
+                  .catch(reject);
+              }, delay * callCount)
+            );
           });
         }
         return Promise.reject(e);
@@ -1026,6 +1030,7 @@ export function decorateAsyncAction<S, DS, F extends (...args: any[]) => any, A 
     derivedStateRef,
     propsRef,
     actionsRef,
+    timeoutRef,
     promisesRef,
     loadingParallelMapRef: loadingMapRef,
     errorMapRef,
@@ -1096,6 +1101,11 @@ export function decorateAsyncAction<S, DS, F extends (...args: any[]) => any, A 
 
     const promiseProvider = retryPromiseDecorator(
       action.getPromise,
+      (timeoutId) => {
+        if (timeoutRef.current) {
+          timeoutRef.current[actionName] = timeoutId;
+        }
+      },
       retryCount ? 1 + retryCount : 1,
       retryDelaySeed,
       isTriggerRetryError || globalConfig.retryOnErrorFunction
@@ -1284,7 +1294,7 @@ export function computeDerivedValues<S, A, P, DS>(
   p: Ref<P>,
   derivedStateRef: Ref<DerivedState<DS>>,
   options: StoreOptions<S, A, P, DS>,
-  derivedStateOverrideRef: Ref<DS> = null
+  derivedStateOverrideRef: Ref<Partial<DS>> = null
 ): boolean {
   if (options?.derivedState == null) {
     return false;
@@ -1421,6 +1431,11 @@ export function onPropChange<S, P, A, DS>(
   isInit: boolean,
   isDeferred: boolean
 ) {
+  // store is destroyed
+  if (stateRef.current == null) {
+    return;
+  }
+
   const hasDerivedState = options?.derivedState != null;
 
   if (options.onPropsChange == null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,6 +441,9 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
 
       propsRef.current = null;
       stateRef.current = null;
+      // Lifecycle tests
+      // allow to call action without crash
+      // actionsRef.current = null;
       loadingParallelMapRef.current = null;
       loadingMapRef.current = null;
       loadingRef.current = null;
@@ -558,6 +561,7 @@ export function createStore<S, A extends DecoratedActions, P, DS = {}>(
         promisesRef,
         conflictActionsRef,
         initializedRef,
+        timeoutRef,
         options,
         setState,
         clearError,

--- a/src/test.ts
+++ b/src/test.ts
@@ -588,6 +588,7 @@ export function createMockStoreAction<S, A extends DecoratedActions, F extends (
             promisesRef,
             conflictActionsRef,
             initializedRef,
+            timeoutRef: createRef({}),
             options,
             setState,
             stateRef: newStateRef,

--- a/tests/AsyncActions.test.ts
+++ b/tests/AsyncActions.test.ts
@@ -12,9 +12,9 @@
  * @jest-environment jsdom
  */
 
-import { EffectError, globalConfig } from '../src/impl';
-import { createStore, setGlobalConfig } from '../src/index';
-import { StoreAction, StoreActions } from '../src/types';
+import { EffectError, globalConfig, Ref } from '../src/impl';
+import { createStore, setGlobalConfig, StoreApi } from '../src/index';
+import { StoreAction, StoreActions, StoreConfig } from '../src/types';
 import { getFailedTimeoutPromise, getTimeoutPromise } from './utils';
 
 describe('Async action', () => {
@@ -365,6 +365,63 @@ describe('Async action', () => {
     expect(isLoading('successAction')).toBeFalsy();
 
     return promise;
+  });
+
+  it('call another action on error but store trashed', (done) => {
+    type State = {
+      a: number;
+    };
+    type Actions = {
+      a1: () => Promise<number>;
+      a2: () => Promise<number>;
+    };
+    type Props = {};
+
+    let callCount = 0;
+
+    const ref: Ref<StoreApi<State, Actions, Props>> = {
+      current: null,
+    };
+
+    const config: StoreConfig<State, Actions, Props> = {
+      initialState: { a: 1 },
+      actions: {
+        a1: {
+          retryCount: 1,
+          retryDelaySeed: 20,
+          getPromise: ({ a }) => {
+            if (callCount === 0) {
+              callCount++;
+
+              setTimeout(() => {
+                ref.current.destroy();
+                setTimeout(() => {
+                  done();
+                }, 50);
+              }, 10);
+              return Promise.reject(new TypeError());
+            }
+
+            done.fail();
+
+            const p = a.a2();
+
+            return p;
+          },
+          effects: ({ res }) => ({ a: res }),
+        },
+        a2: {
+          getPromise: () => Promise.resolve(10),
+        },
+      },
+    };
+
+    const store = createStore(config);
+    ref.current = store;
+
+    store.init({});
+
+    store.actions.a1().catch();
   });
 
   it('error action', (done) => {

--- a/tests/PropsChange.test.ts
+++ b/tests/PropsChange.test.ts
@@ -363,4 +363,25 @@ describe('onPropsChange', () => {
       expect(callback2).not.toHaveBeenCalled();
     });
   });
+
+  it('onPropsChange on destroyed store', () => {
+    const store = createStore<State, Actions, Props>({
+      getInitialState,
+      actions: actions,
+      onPropsChange: options.onPropsChange,
+    });
+
+    store.init({
+      input: '',
+      input2: '',
+    });
+
+    store.destroy();
+
+    // should not crash
+    store.setProps({
+      input: '2',
+      input2: '3',
+    });
+  });
 });


### PR DESCRIPTION
[FIX]: register timeout ID of setTimeout of getPromise retry error to be cleared on destroy
[FIX]: prevent onPropsChange on destroyed store